### PR TITLE
Download the forms archive in addition to checking the version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         git config --global user.name github-actions
         git config --global user.email github-actions@github.com
-        
+
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -40,7 +40,9 @@ jobs:
     - name: Update Forms Version
       run: |
         go run update-forms-ver.go > ghpages/v1/forms/standard-templates/latest
+        rm ghpages/v1/forms/standard-templates/Standard_Forms*.zip
+        mv Standard_Forms*.zip ghpages/v1/forms/standard-templates
         cd ghpages
-        git add v1/forms/standard-templates/latest
+        git add v1/forms/standard-templates/*
         git commit -m "Update form template version"
         git push origin ghpages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Standard_Forms_*.zip
+/.idea


### PR DESCRIPTION
We have a few reports from the mailing list (e.g. [this one](https://groups.google.com/g/pat-users/c/haiP_jGK9qg/)) of errors when updating forms, sometimes in the form of timeouts. Short of network problems (user reports that's not the case) or MS OneDrive outage (possible but shouldn't happen often), there's another possibility in the design of the system.

Because this repo's GitHub action triggers scraping once an hour, there's a time period during which an update on the Winlink site could leave us with a stale download URL, which could cause 404s or timeouts. To give us more control, this PR will start downloading the forms archive and serving it through Github Pages.

This PR does not yet change the archive URL published in the `latest` document. Instead, it logs the URL and commits the forms archive so we can test and make sure the change works before making it live.