### PR TITLE
Don't output Generated timestamp

### DIFF
--- a/update-forms-ver.go
+++ b/update-forms-ver.go
@@ -18,7 +18,7 @@ import (
 type FormsInfo struct {
 	Version    string    `json:"version"`
 	ArchiveURL string    `json:"archive_url"`
-	Generated  time.Time `json:"_generated"`
+	Generated  time.Time `json:"-"`
 }
 
 func (f FormsInfo) String() string {


### PR DESCRIPTION
Maybe only my OCD, but it seems excessive to force an update (and commit) only to update the timestamp. We can use the Actions status to see the same information.

We might need to modify the Actions script not to fail when git commit/push commands see no changes though.

What do you think, @xylo04?